### PR TITLE
Fix context error in updateButtonTitle

### DIFF
--- a/src/DropdownDivConverter/widget/DropdownDivConverter.js
+++ b/src/DropdownDivConverter/widget/DropdownDivConverter.js
@@ -281,7 +281,7 @@ define([
         // update the dynamic button title
         _updateButtonTitle: function() {
             this._buttonLabel = this.buttonTitle;
-            if (this._dynamicLabel) {
+            if (this._dynamicLabel && this._contextObj) {
                 this._buttonLabel = this._contextObj.get(this.dynamicButtonTitleAttribute);
             }
         },


### PR DESCRIPTION
Fixes *.*.dropdownDivConverter1: Error while applying context TypeError: Cannot read property 'get' of null